### PR TITLE
Readability cleanup & minor fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.gitignore
+.git
+.gitmodules
+bootstrap.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM mwcampbell/muslbase-build-base
-ENV ROOT /newroot
-RUN mkdir $ROOT
-ADD . $ROOT/src
+MAINTAINER Matt Campbell <mattcampbell@pobox.com>
+
+ENV ROOT /buildroot
 ENV RUNTIME_ROOT $ROOT/runtime
-RUN mkdir $RUNTIME_ROOT
-env STATIC_RUNTIME_ROOT $ROOT/static-runtime
-RUN mkdir $STATIC_RUNTIME_ROOT
-RUN $ROOT/src/build-prerequisites.sh && \
-    $ROOT/src/build-temporary.sh
+ENV STATIC_RUNTIME_ROOT $ROOT/static-runtime
+
+RUN mkdir -p $RUNTIME_ROOT $STATIC_RUNTIME_ROOT
+
+ADD . $ROOT/src
+
+RUN $ROOT/src/build-prerequisites.sh
+RUN $ROOT/src/build-temporary.sh
+
 ADD dev.tar $ROOT/dev/
 ADD dev.tar $RUNTIME_ROOT/dev
 ADD dev.tar $STATIC_RUNTIME_ROOT/dev
+
 RUN chroot $ROOT /src/build-final.sh && \
     rm -rf $ROOT/src && \
     rm -rf $ROOT/tools && \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,35 +1,56 @@
 #!/bin/sh
+
 set -e
-if [ -z "$1" ]
-then
-  echo "Usage: $0 username" >&2
-  exit 1
+
+# Check if script is run correctly
+if [ -z "$1" ]; then
+	echo "Usage: $0 username" >&2
+	exit 1
 fi
+
 username="$1"
+
+# Download/Update all dependencies
 git submodule update --init
+
+# Clean/Remove built environment
 docker rmi mwcampbell/muslbase-build-base || true
 docker rmi $username/muslbase-build || true
-for buildbase in debian selfhost selfhost
-do
-  if [ "$buildbase" = "selfhost" ]
-  then
-    docker tag $username/muslbase mwcampbell/muslbase-build-base
-  else
-    docker build --rm -t=mwcampbell/muslbase-build-base buildbase/$buildbase
-  fi
-  docker rmi $username/muslbase || true
-  docker rmi $username/muslbase-runtime || true
-  docker rmi $username/muslbase-static-runtime || true
-  docker build --rm -t=$username/muslbase-build .
-  docker run --rm $username/muslbase-build cat /rootfs.tar > rootfs/full/rootfs.tar
-  docker build --rm -t=$username/muslbase rootfs/full
-  rm rootfs/full/rootfs.tar
-  docker run --rm $username/muslbase-build cat /runtime-rootfs.tar > rootfs/runtime/rootfs.tar
-  docker build --rm -t=$username/muslbase-runtime rootfs/runtime
-  rm rootfs/runtime/rootfs.tar
-  docker run --rm $username/muslbase-build cat /static-runtime-rootfs.tar > rootfs/static-runtime/rootfs.tar
-  docker build --rm -t=$username/muslbase-static-runtime rootfs/static-runtime
-  rm rootfs/static-runtime/rootfs.tar
-  docker rmi mwcampbell/muslbase-build-base
-  docker rmi $username/muslbase-build
+
+# Build, first using glibc from debian, then musl from selfhost build environment
+for buildbase in debian selfhost selfhost; do
+	if [ "$buildbase" = "selfhost" ]; then
+		# Next use muslbase as build environment
+		docker tag $username/muslbase mwcampbell/muslbase-build-base
+	else
+		# Build initial debian base build environment
+		docker build --rm -t=mwcampbell/muslbase-build-base buildbase/$buildbase
+	fi
+
+	# Remove earlier muslbase images
+	docker rmi $username/muslbase || true
+	docker rmi $username/muslbase-runtime || true
+	docker rmi $username/muslbase-static-runtime || true
+
+	# Build muslbase rootfs
+	docker build --rm -t=$username/muslbase-build .
+
+	# Build docker image: muslbase
+	docker run --rm $username/muslbase-build cat /rootfs.tar > rootfs/full/rootfs.tar
+	docker build --rm -t=$username/muslbase rootfs/full
+	rm rootfs/full/rootfs.tar
+
+	# Build docker image: muslbase-runtime
+	docker run --rm $username/muslbase-build cat /runtime-rootfs.tar > rootfs/runtime/rootfs.tar
+	docker build --rm -t=$username/muslbase-runtime rootfs/runtime
+	rm rootfs/runtime/rootfs.tar
+
+	# Build docker image: muslbase-static-runtime
+	docker run --rm $username/muslbase-build cat /static-runtime-rootfs.tar > rootfs/static-runtime/rootfs.tar
+	docker build --rm -t=$username/muslbase-static-runtime rootfs/static-runtime
+	rm rootfs/static-runtime/rootfs.tar
+
+	# Clean/Remove build environment
+	docker rmi mwcampbell/muslbase-build-base
+	docker rmi $username/muslbase-build
 done

--- a/build-final.sh
+++ b/build-final.sh
@@ -3,22 +3,25 @@
 
 # Setup
 set -e
+
 umask 022
+
 jobs=-j8
+
 configure_args='--prefix= --libdir=/lib --libexecdir=/lib --bindir=/bin --sbindir=/sbin --sysconfdir=/etc --includedir=/include --localstatedir=/var --mandir=/share/man --infodir=/share/info'
+
 export LC_ALL=POSIX
 export PATH=/bin:/sbin:/tools/bin
 export SRC=/src
 export DEPS=$SRC/deps
 export PATCHDIR=$SRC/patches
 
-for script in $SRC/steps/final/*
-do
-  mkdir /work
-  cd /work
-  echo Running $script
-  . $script
-  cd /
-  rm -rf /work
-  hash -r
+for script in $SRC/steps/final/*; do
+	mkdir /work
+	cd /work
+	echo Running $script
+	. $script
+	cd /
+	rm -rf /work
+	hash -r
 done

--- a/build-prerequisites.sh
+++ b/build-prerequisites.sh
@@ -3,20 +3,22 @@
 
 # Setup
 set -e
+
 umask 022
+
 jobs=-j8
+
 export LC_ALL=POSIX
 export SRC=$ROOT/src
 export DEPS=$SRC/deps
 export PATCHDIR=$SRC/patches
 
-for script in $SRC/steps/prerequisites/*
-do
-  mkdir $ROOT/work
-  cd $ROOT/work
-  echo Running $script
-  . $script
-  cd $ROOT
-  rm -rf $ROOT/work
-  hash -r
+for script in $SRC/steps/prerequisites/*; do
+	mkdir $ROOT/work
+	cd $ROOT/work
+	echo Running $script
+	. $script
+	cd $ROOT
+	rm -rf $ROOT/work
+	hash -r
 done

--- a/build-temporary.sh
+++ b/build-temporary.sh
@@ -3,31 +3,35 @@
 
 # Setup
 set -e
+
 umask 022
+
 export BUILD=x86_64-unknown-linux-gnu
 export TARGET=x86_64-muslbasecross-linux-gnu
+
 CC=gcc
 CXX=g++
 jobs=-j8
+
 export LC_ALL=POSIX
 export PATH=/tools/bin:$PATH
 export SRC=$ROOT/src
 export DEPS=$SRC/deps
 export PATCHDIR=$SRC/patches
+
 cd $ROOT
 rm -rf tools
 mkdir tools
 ln -s $ROOT/tools /tools
 
-for script in $SRC/steps/temporary/*
-do
-  mkdir $ROOT/work
-  cd $ROOT/work
-  echo Running $script
-  . $script
-  cd $ROOT
-  rm -rf $ROOT/work
-  hash -r
+for script in $SRC/steps/temporary/*; do
+	mkdir $ROOT/work
+	cd $ROOT/work
+	echo Running $script
+	. $script
+	cd $ROOT
+	rm -rf $ROOT/work
+	hash -r
 done
 
 # Cleanup

--- a/buildbase/debian/Dockerfile
+++ b/buildbase/debian/Dockerfile
@@ -1,3 +1,4 @@
 FROM debian:wheezy
-RUN apt-get -y update
-RUN apt-get -y install libc6-dev binutils gcc g++ make patch
+MAINTAINER Matt Campbell <mattcampbell@pobox.com>
+
+RUN apt-get -y update && apt-get -y install libc6-dev binutils gcc g++ make patch

--- a/rootfs/full/Dockerfile
+++ b/rootfs/full/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
 MAINTAINER Matt Campbell <mattcampbell@pobox.com>
+
 ADD rootfs.tar /
 ENV PATH /local/sbin:/local/bin:/sbin:/bin

--- a/rootfs/runtime/Dockerfile
+++ b/rootfs/runtime/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
 MAINTAINER Matt Campbell <mattcampbell@pobox.com>
+
 ADD rootfs.tar /
 ENV PATH /local/sbin:/local/bin:/sbin:/bin

--- a/rootfs/static-runtime/Dockerfile
+++ b/rootfs/static-runtime/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
 MAINTAINER Matt Campbell <mattcampbell@pobox.com>
+
 ADD rootfs.tar /
 ENV PATH /local/sbin:/local/bin:/sbin:/bin


### PR DESCRIPTION
I redid all my improvements and split it all up into 4 commits.

First I added a badly needed .dockerignore file. It will save you a lot of time when we don't add the entire git history to the build containers.

Secondly I did a cleanup of the main Dockerfile, including the changes that somehow made my issues disappear.

Thirdly I fixed your Debian base Dockerfile, that did not follow some best practices regarding the apt cache & layering. Simply put, if Debian pushes updates to the package repositories at the wrong time (no matter how unlikely) things could break.

Lastly I changed all white spaces into tabs, added empty new line separators and minor readability tweaks.on most scripts and all the rest of the Dockerfiles.

If you prefer 2 spaces long indentation, I recommend using an editor that supports setting a custom length (which only works if you use tabs). Thus to make things easier for potential contributors I recommend tabs.

As you might see in the comments of the bootstrap.sh file,  I did figure out the role of the loop and the if statement.

But I could never figure out why it needed to be run 3 times, instead of just 2. Changing it to a 2 times loop resulted in images of exact same size and contents. I also discovered a minor time saver that could be easily implemented if the muslbase-runtime and muslbase-static-runtime only was created the last loop run.

All of that I will address in a second pull request, after we have had time to discuss this one. I figured that was a slightly larger issue and a slightly greater chance of me missing something.
